### PR TITLE
Use Python 3.13 for ReadTheDocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,7 +4,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.14"
+    python: "3.13"
 
 sphinx:
   configuration: docs/source/conf.py


### PR DESCRIPTION
ReadTheDocs does not yet support Python 3.14.